### PR TITLE
Modified code to add custom blocks

### DIFF
--- a/seesaw.ts
+++ b/seesaw.ts
@@ -313,16 +313,19 @@ Implementation Notes
     const _HW_ID_CODE = 0x55
     const _EEPROM_I2C_ADDR = 0x3F
 
+    //ADC pins
     const ADC_INPUT_0_PIN = 2
     const ADC_INPUT_1_PIN = 3
     const ADC_INPUT_2_PIN = 4
 
+    //PWM pins
     const PWM_0_PIN = 4
     const PWM_1_PIN = 5
     const PWM_2_PIN = 6
     const PWM_3_PIN = 7
 
     export class SeesawPinmap {
+        /* Defined */
         //  analogPins: number[]
         //  pwmWidth: number
         //  pwmPins: number[]
@@ -415,7 +418,7 @@ Implementation Notes
         //% weight=80 blockGap=8
         public digitalWrite(pin: digitalPins, value: number) {
             let buf = this.getPinArray(pin)
-            this.pinModeBulk(buf, ioConfig.output)
+            this.pinModeBulk(buf, ioConfig.output) //Set pin mode
             this.dWriteBulk(buf, value)
         }
 
@@ -427,7 +430,7 @@ Implementation Notes
         //% weight=60 blockGap=8
         public digitalRead(pin: digitalPins): boolean {
             let buf = this.getPinArray(pin)
-            this.pinModeBulk(buf, ioConfig.input)
+            this.pinModeBulk(buf, ioConfig.input) //Set pin mode
             let readVals = this.dReadBulk(buf)
             for (let i = 0; i < 8; i++) {
                 if (readVals[i] > 0) {
@@ -450,7 +453,7 @@ Implementation Notes
             cmd[1] = pinSet >> 16
             cmd[2] = pinSet >> 8
             cmd[3] = pinSet
-            this.pinModeBulk(cmd, ioConfig.input)
+            this.pinModeBulk(cmd, ioConfig.input) //Set pin mode
             let data = this.dReadBulk(cmd)
 
             data[2] = data[2] << 8
@@ -487,7 +490,7 @@ Implementation Notes
         //% weight=40 blockGap=8
         public analogRead(pin: analogPins): number {
             let buf = this.getPinArray(pin)
-            this.pinModeBulk(buf, ioConfig.input)
+            this.pinModeBulk(buf, ioConfig.input) //Set pin mode
             let cmd = pins.createBuffer(2)
             let p = 0
             switch (pin) {
@@ -550,7 +553,7 @@ Implementation Notes
             cmd[1] = pinSet >> 16
             cmd[2] = pinSet >> 8
             cmd[3] = pinSet
-            this.pinModeBulk(cmd, ioConfig.output)
+            this.pinModeBulk(cmd, ioConfig.output) //Set pin mode
             this.dWriteBulk(cmd, value)
         }
 

--- a/test.ts
+++ b/test.ts
@@ -1,10 +1,10 @@
 const dev = new seesaw.Seesaw(null)
-//dev.pinMode(15, 1)
+//dev.pinMode(15, 1) // Pin mode is set in digitalWrite() function
 
 // blinky
 for (let i = 0; i < 10; ++i) {
     dev.digitalWrite(15, 1)
     basic.pause(500)
     dev.digitalWrite(15, 0)
-    basic.pause(500)    
+    basic.pause(500)
 }

--- a/test.ts
+++ b/test.ts
@@ -1,10 +1,10 @@
 const dev = new seesaw.Seesaw(null)
-dev.pinMode(15, 1)
+//dev.pinMode(15, 1)
 
 // blinky
 for (let i = 0; i < 10; ++i) {
-    dev.digitalWrite(15, true)
+    dev.digitalWrite(15, 1)
     basic.pause(500)
-    dev.digitalWrite(15, false)
+    dev.digitalWrite(15, 0)
     basic.pause(500)    
 }

--- a/test.ts
+++ b/test.ts
@@ -1,10 +1,7 @@
-const dev = new seesaw.Seesaw(null)
-//dev.pinMode(15, 1) // Pin mode is set in digitalWrite() function
-
-// blinky
-for (let i = 0; i < 10; ++i) {
-    dev.digitalWrite(15, 1)
-    basic.pause(500)
-    dev.digitalWrite(15, 0)
-    basic.pause(500)
-}
+let SeeSaw = seesaw.create(sAddr.add1)
+basic.forever(function () {
+    SeeSaw.digitalWrite(digitalPins.P9, 1)
+    basic.pause(100)
+    SeeSaw.digitalWrite(digitalPins.P9, 0)
+    basic.pause(100)
+})


### PR DESCRIPTION
These changes allow to use this package for blocks in makecode microbit editor

**Things modified**
1. Defined ADC and PWM pins (not using pinMapping).
2. Changed "digitalWrite" function's input from boolean to number.
3. Pin mode will be set automatically when calling any write or read function.
4. Changed "bulk" function's input from buffer to number. 

**NOTES**
_"bulk" functions_

- pinSet - Convert binary value of pins to decimals 

- Convert returned data to binary value to get the pin's reading
